### PR TITLE
vagrant ssh command

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -190,7 +190,7 @@ common_vagrant() {
 common_done() {
     echo_head "Done bootstrapping environment."
     msg "All virtual machines should be running."
-    msg "Run \033[1;36mvagrant ssh ewallet\033[0;0m to access ewallet box."
+    msg "Run \033[1;36mvagrant ssh\033[0;0m to access ewallet box."
     msg "Run \033[1;36mvagrant halt\033[0;0m to shutdown everything."
     msg "Run \033[1;36mvagrant up\033[0;0m for subsequent boot."
     msg "Run \033[1;36mvagrant provision\033[0;0m to re-provision the virtual machine."


### PR DESCRIPTION
The `ewallet` part of the vagrant command doesn't seem necessary