### PR TITLE
Add node and yarn to Goban's provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 Goban (["Go board"](https://en.wikipedia.org/wiki/Go_equipment#Board)) is an environment bootstrapper for OmiseGO-related projects. Goban utilizes [Vagrant](http://www.vagrantup.com/) and [Ansible](http://www.ansible.com/) to provision a virtual machine that resembles production environment. Goban bootstraps the following components with the following dependencies:
 
-| Component    | Vagrant Box | Erlang      | Elixir   | PostgreSQL    |
-| ------------ | ----------- | ----------- | -------- | ------------- |
-| **eWallet**  | Debian 9₁   | OTP 20.2.2₂ | 1.5.2₂   | PostgreSQL 9₃ |
+| Component    | Vagrant Box | Erlang      | Elixir   | PostgreSQL    | Node.js | Yarn   |
+| ------------ | ----------- | ----------- | -------- | ------------- | ------- | ------ |
+| **eWallet**  | Debian 9₁   | OTP 20.2.2₂ | 1.5.2₂   | PostgreSQL 9₃ | 8.9.4₄  | 1.5.1₅ |
 
 * ₁ Using [bento/debian-9](https://app.vagrantup.com/bento/boxes/debian-9) Vagrant box for its provider support.
 * ₂ Using the release from [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html). The installed version may be newer.
 * ₃ Running in a Docker container inside a VM using the [postgres:9](https://hub.docker.com/_/postgres/) image.
+* ₄ Using a pinned version from [NodeSource](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions).
+* ₅ Using a pinned version from [Yarn](https://yarnpkg.com/lang/en/docs/install/). The installed version may be newer.
 
 ## Prerequisites
 

--- a/provisioning/roles/ewallet/tasks/ewallet.yml
+++ b/provisioning/roles/ewallet/tasks/ewallet.yml
@@ -9,6 +9,8 @@
   command: yarn install
   args:
     chdir: /vagrant/apps/admin_panel/assets
+  register: yarn_result
+  changed_when: "'Already up-to-date' not in yarn_result.stdout"
 
 - name: perform initial setup
   shell: |

--- a/provisioning/roles/ewallet/tasks/ewallet.yml
+++ b/provisioning/roles/ewallet/tasks/ewallet.yml
@@ -5,6 +5,11 @@
     chdir: "{{ansible_env['HOME']}}"
     creates: "{{ansible_env['HOME']}}/.mix/rebar"
 
+- name: install yarn dependencies
+  command: yarn install
+  args:
+    chdir: /vagrant/apps/admin_panel/assets
+
 - name: perform initial setup
   shell: |
     mix deps.get && \

--- a/provisioning/roles/ewallet/tasks/main.yml
+++ b/provisioning/roles/ewallet/tasks/main.yml
@@ -3,4 +3,6 @@
 - import_tasks: packages/erlang.yml
 - import_tasks: packages/imagemagick.yml
 - import_tasks: packages/libsodium.yml
+- import_tasks: packages/node.yml
+- import_tasks: packages/yarn.yml
 - import_tasks: ewallet.yml

--- a/provisioning/roles/ewallet/tasks/packages/node.yml
+++ b/provisioning/roles/ewallet/tasks/packages/node.yml
@@ -1,0 +1,12 @@
+---
+- name: install nodejs gpg key
+  become: yes
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
+- name: install nodejs
+  become: yes
+  apt:
+    deb: https://deb.nodesource.com/node_8.x/pool/main/n/nodejs/nodejs_8.9.4-1nodesource1_amd64.deb
+    state: present

--- a/provisioning/roles/ewallet/tasks/packages/yarn.yml
+++ b/provisioning/roles/ewallet/tasks/packages/yarn.yml
@@ -1,0 +1,18 @@
+---
+- name: install yarn gpg key
+  become: yes
+  apt_key:
+    url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    state: present
+
+- name: install yarn repository
+  become: yes
+  apt_repository:
+    repo: deb https://dl.yarnpkg.com/debian/ stable main
+    state: present
+
+- name: install yarn
+  become: yes
+  apt: name={{item}} state=present
+  with_items:
+    - yarn=1.5.1-1


### PR DESCRIPTION
Issue/Task Number: T510

# Overview

This PR adds node (required by jest) and yarn to support the upcoming Admin Panel front end.

# Changes

- Added `node.yml` for nodejs installation
- Added `yarn.yml` for yarn installation

# Implementation Details

- Yarn installation is the same way as other packages currently in Goban
- Nodejs's version pinning seems to have [an issue](https://github.com/nodesource/distributions/issues/33). A nodesource contributor suggested [using the `deb` flag to point to a specific `.deb` path instead](https://github.com/nodesource/distributions/issues/33#issuecomment-169345680)

# Usage

From your goban directory on your host machine, run `vagrant provision`. The provisioning should complete successfully and you should see the following tasks completed:

```
TASK [ewallet : install nodejs gpg key] ****************************************
changed: [ewallet]

TASK [ewallet : install nodejs] ************************************************
changed: [ewallet]

TASK [ewallet : install yarn gpg key] ******************************************
changed: [ewallet]

TASK [ewallet : install yarn repository] ***************************************
changed: [ewallet]

TASK [ewallet : install yarn] **************************************************
changed: [ewallet] => (item=[u'yarn=1.5.1-1'])

TASK [ewallet : install yarn dependencies] *************************************
changed: [ewallet]
```

# Impact

Pull the latest commit. Run `vagrant provision` from your host machine.