### PR TITLE
Bump Elixir version up to 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Goban (["Go board"](https://en.wikipedia.org/wiki/Go_equipment#Board)) is an env
 
 | Component    | Vagrant Box | Erlang      | Elixir   | PostgreSQL    | Node.js | Yarn   |
 | ------------ | ----------- | ----------- | -------- | ------------- | ------- | ------ |
-| **eWallet**  | Debian 9₁   | OTP 20.2.2₂ | 1.5.2₂   | PostgreSQL 9₃ | 8.9.4₄  | 1.5.1₅ |
+| **eWallet**  | Debian 9₁   | OTP 20.2.2₂ | 1.6.1₂   | PostgreSQL 9₃ | 8.9.4₄  | 1.5.1₅ |
 
 * ₁ Using [bento/debian-9](https://app.vagrantup.com/bento/boxes/debian-9) Vagrant box for its provider support.
 * ₂ Using the release from [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html). The installed version may be newer.

--- a/provisioning/roles/ewallet/tasks/packages/erlang.yml
+++ b/provisioning/roles/ewallet/tasks/packages/erlang.yml
@@ -16,4 +16,4 @@
   apt: name={{item}} state=present
   with_items:
     - esl-erlang=1:20.2.2
-    - elixir=1.5.2-1
+    - elixir=1.6.1-1


### PR DESCRIPTION
Issue/Task Number: T57

# Overview

Bump Elixir version up to 1.6.1

# Changes

- Updated Ansible config to install Elixir `1.6.1-1` instead of `1.5.2-1`

# Implementation Details

I originally wanted to upgrade to 1.6.3 right away (released 3 days ago) but the package is not available on `aptitude` yet. So I upgraded to 1.6.1-1 the latest from `apt list -a elixir` instead.

# Usage

After pulling this PR and run `vagrant provision`. SSH into goban environment and `elixir --version` should show the following:

```sh
vagrant@ewallet:/vagrant$ elixir --version
Erlang/OTP 20 [erts-9.2] [source] [64-bit] [smp:1:1] [ds:1:1:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.6.1 (compiled with OTP 19)
```

# Impact

Run `vagrant provision` after pulling this PR.