### PR TITLE
Ignore ewallet directory even in case of symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ Thumbs.db
 *.iml
 
 # Workspace
-/ewallet/
+/ewallet
 
 # Ansible
 playbook.retry


### PR DESCRIPTION
Using `/ewallet/` only make Git ignores `ewallet` as a directory. We have to use `/ewallet` for ignoring symlink.