### PR TITLE
Add ewallet & ledger postgres user with CREATEDB permission

### DIFF
--- a/provisioning/group_vars/all/main.yml
+++ b/provisioning/group_vars/all/main.yml
@@ -1,7 +1,7 @@
 ---
 ansible_python_interpreter: /usr/bin/python3
 
-postgres_user: "{{ansible_user}}"
+postgres_user: "postgres"
 postgres_db: "{{postgres_user}}"
 postgres_password: "{{postgres_user}}"
 

--- a/provisioning/roles/postgres/tasks/main.yml
+++ b/provisioning/roles/postgres/tasks/main.yml
@@ -17,6 +17,7 @@
     mode: 0755
   with_items:
     - 01_init_hba.sh
+    - 02_init_user.sh
   notify:
     - restart postgres container
 

--- a/provisioning/roles/postgres/templates/srv/postgres/initdb/02_init_user.sh.j2
+++ b/provisioning/roles/postgres/templates/srv/postgres/initdb/02_init_user.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "{{postgres_user}}" <<-EOSQL
+  CREATE USER {{ewallet_postgres_user}} WITH ENCRYPTED PASSWORD '{{ewallet_postgres_user}}' CREATEDB;
+EOSQL

--- a/provisioning/roles/postgres/vars/main.yml
+++ b/provisioning/roles/postgres/vars/main.yml
@@ -1,0 +1,2 @@
+---
+ewallet_postgres_user: "{{ansible_user}}"


### PR DESCRIPTION
This PR creates two new database users `ewallet` and `ledger` without superuser privileges to better mimic the database settings in the real world, i.e. apps will be accessing the database as a non-superuser.